### PR TITLE
Request Logger Infra for Twitter using Scribe

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -230,6 +230,8 @@
                                         <argument>org.apache.druid.extensions:simple-client-sslcontext</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-basic-security</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.twitter:scribe-emitter</argument>
                                         <argument>${druid.distribution.pulldeps.opts}</argument>
                                     </arguments>
                                 </configuration>

--- a/extensions-twitter/scribe-emitter/pom.xml
+++ b/extensions-twitter/scribe-emitter/pom.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>druid</artifactId>
+    <groupId>org.apache.druid</groupId>
+    <version>0.16.1-tw-0.1</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.druid.extensions.twitter</groupId>
+  <artifactId>scribe-emitter</artifactId>
+  <name>scribe-emitter</name>
+  <description>Extension for emitting Druid audit logs via Scribe</description>
+
+  <properties>
+    <thrift.version>0.10.0</thrift.version>
+    <scala.version>2.10.6</scala.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-core</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${thrift.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>util-logging_2.10</artifactId>
+      <version>6.34.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.thrift.tools</groupId>
+        <artifactId>maven-thrift-plugin</artifactId>
+        <version>0.1.11</version>
+        <configuration>
+          <thriftExecutable>/usr/local/bin/thrift</thriftExecutable>
+          <thriftSourceRoot>${basedir}/src/main/resources/thrift</thriftSourceRoot>
+        </configuration>
+        <executions>
+          <execution>
+            <id>thrift-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>thrift-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeEmitter.java
+++ b/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeEmitter.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.scribe;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.java.util.emitter.core.Emitter;
+import org.apache.druid.java.util.emitter.core.Event;
+import org.apache.druid.server.log.RequestLogEvent;
+import org.apache.thrift.TException;
+
+public class ScribeEmitter implements Emitter
+{
+  private ObjectMapper jsonMapper;
+
+  private static Logger log = new Logger(ScribeEmitter.class);
+
+  private final TwitterLogScriber requestLogScriber;
+  private final ScribeEmitterConfig scribeEmitterConfig;
+
+  public ScribeEmitter(
+      ScribeEmitterConfig scribeEmitterConfig,
+      ObjectMapper jsonMapper
+  )
+  {
+    this.requestLogScriber = new TwitterLogScriber(scribeEmitterConfig.getRequestLogScribeCategory());
+    this.scribeEmitterConfig = scribeEmitterConfig;
+    this.jsonMapper = jsonMapper;
+  }
+
+  @Override
+  public void start()
+  {
+
+  }
+
+  @Override
+  public void emit(Event event)
+  {
+    if (event instanceof RequestLogEvent) {
+      try {
+        requestLogScriber.scribe(ScribeRequestLogEntry.createScribeRequestLogEntry(event, scribeEmitterConfig, jsonMapper).toThrift());
+      }
+      catch (JsonProcessingException e) {
+        log.warn("" + e + " Could not process native query string as JSON object " + event);
+      }
+      catch (TException e) {
+        log.warn("" + e + ", Could not serialize thrift object of query: " + event);
+      }
+    }
+  }
+
+  @Override
+  public void flush()
+  {
+    requestLogScriber.flush();
+  }
+
+  @Override
+  public void close()
+  {
+    requestLogScriber.close();
+  }
+}

--- a/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeEmitterConfig.java
+++ b/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeEmitterConfig.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.scribe;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ScribeEmitterConfig
+{
+  @JsonProperty
+  private final String requestLogScribeCategory;
+
+  @JsonProperty
+  private final String role;
+
+  @JsonProperty
+  private final String environment;
+
+  @JsonProperty
+  private final String druidVersion;
+
+  @JsonProperty
+  private final String dataCenter;
+
+  @JsonProperty
+  private final String clusterName;
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ScribeEmitterConfig)) {
+      return false;
+    }
+
+    ScribeEmitterConfig that = (ScribeEmitterConfig) o;
+
+    if (!getRequestLogScribeCategory().equals(that.getRequestLogScribeCategory())) {
+      return false;
+    }
+    if (!getRole().equals(that.getRole())) {
+      return false;
+    }
+    if (!getEnvironment().equals(that.getEnvironment())) {
+      return false;
+    }
+    if (!getDruidVersion().equals(that.getDruidVersion())) {
+      return false;
+    }
+    if (!getDataCenter().equals(that.getDataCenter())) {
+      return false;
+    }
+    if (!getClusterName().equals(that.getClusterName())) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = getRequestLogScribeCategory().hashCode();
+    result = 31 * result + getRole().hashCode();
+    result = 31 * result + getEnvironment().hashCode();
+    result = 31 * result + getDruidVersion().hashCode();
+    result = 31 * result + getDataCenter().hashCode();
+    result = 31 * result + getClusterName().hashCode();
+    return result;
+  }
+
+  @JsonCreator
+  public ScribeEmitterConfig(
+      @JsonProperty("requestLogScribeCategory") String requestLogScribeCategory,
+      @JsonProperty("role") String role,
+      @JsonProperty("environment") String environment,
+      @JsonProperty("druidVersion") String druidVersion,
+      @JsonProperty("dataCenter") String dataCenter,
+      @JsonProperty("clusterName") String clusterName
+  )
+  {
+    this.requestLogScribeCategory = requestLogScribeCategory;
+    this.role = role;
+    this.environment = environment;
+    this.druidVersion = druidVersion;
+    this.dataCenter = dataCenter;
+    this.clusterName = clusterName;
+  }
+
+  @JsonProperty
+  public String getRequestLogScribeCategory()
+  {
+    return requestLogScribeCategory;
+  }
+
+  @JsonProperty
+  public String getRole()
+  {
+    return role;
+  }
+
+  @JsonProperty
+  public String getEnvironment()
+  {
+    return environment;
+  }
+
+  @JsonProperty
+  public String getDruidVersion()
+  {
+    return druidVersion;
+  }
+
+  @JsonProperty
+  public String getDataCenter()
+  {
+    return dataCenter;
+  }
+
+  @JsonProperty
+  public String getClusterName()
+  {
+    return clusterName;
+  }
+}

--- a/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeEmitterModule.java
+++ b/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeEmitterModule.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.scribe;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.name.Named;
+import org.apache.druid.guice.JsonConfigProvider;
+import org.apache.druid.guice.ManageLifecycle;
+import org.apache.druid.initialization.DruidModule;
+import org.apache.druid.java.util.emitter.core.Emitter;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ScribeEmitterModule implements DruidModule
+{
+  private static final String EMITTER_TYPE = "scribe";
+
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return Collections.EMPTY_LIST;
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+    JsonConfigProvider.bind(binder, "druid.emitter." + EMITTER_TYPE, ScribeEmitterConfig.class);
+  }
+
+  @Provides
+  @ManageLifecycle
+  @Named(EMITTER_TYPE)
+  public Emitter getEmitter(ScribeEmitterConfig scribeEmitterConfig, ObjectMapper mapper)
+  {
+    return new ScribeEmitter(scribeEmitterConfig, mapper);
+  }
+}

--- a/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeRequestLogEntry.java
+++ b/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeRequestLogEntry.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.scribe;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Joiner;
+import org.apache.druid.java.util.emitter.core.Event;
+import org.apache.druid.query.DataSource;
+import org.apache.druid.query.Query;
+import org.apache.druid.query.QueryDataSource;
+import org.apache.druid.query.TableDataSource;
+import org.apache.druid.query.UnionDataSource;
+import org.apache.druid.server.log.DefaultRequestLogEvent;
+import org.apache.thrift.TBase;
+import java.util.stream.Collectors;
+
+public class ScribeRequestLogEntry
+{
+  private static final String SUCCESS_KEY = "success";
+  private static final String IDENTITY_KEY = "identity";
+  private static final String QUERY_TIME_KEY = "query/time";
+  private static final String QUERY_BYTES_KEY = "query/bytes";
+  private static final String SQL_QUERY_TIME_KEY = "sqlQuery/time";
+  private static final String SQL_QUERY_BYTES_KEY = "sqlQuery/bytes";
+  private static final String SQL_QUERY_ID_KEY = "sqlQueryId";
+  private static final String NATIVE_QUERY_IDS_KEY = "nativeQueryIds";
+  private static final String IMPLY_DATA_CUBE_KEY = "implyDataCube";
+  private static final String IMPLY_FEATURE_KEY = "implyFeature";
+  private static final String IMPLY_USER_KEY = "implyUser";
+  private static final String IMPLY_USER_EMAIL_KEY = "implyUserEmail";
+  private static final String IMPLY_VIEW_KEY = "implyView";
+  private static final String IMPLY_VIEW_TITLE_KEY = "implyViewTitle";
+  private static final String IMPLY_PRIORITY_KEY = "priority";
+
+  private String native_query_id;
+  private String sql_query_id;
+  private String role;
+  private String druid_version;
+  private String environment;
+  private String dataCenter;
+  private String cluster_name;
+  private String service_name;
+  private String host;
+  private String remote_address;
+  private boolean is_sql_query;
+  private String query;
+  private String datasource;
+
+  private boolean success;
+  private long creation_time;
+  private long execution_time;
+  private long output_result_size;
+  private String authenticator;
+  private String stats;
+
+  private String imply_data_cube;
+  private String imply_feature;
+  private String imply_user;
+  private String imply_user_email;
+  private String imply_view;
+  private String imply_view_title;
+  private int imply_priority;
+
+  public ScribeRequestLogEntry(Event event, ScribeEmitterConfig config, ObjectMapper jsonMapper) throws JsonProcessingException
+  {
+    DefaultRequestLogEvent requestLogEvent = (DefaultRequestLogEvent) event;
+
+    if (requestLogEvent.getQuery() != null) {
+      this.is_sql_query = false;
+      this.native_query_id = requestLogEvent.getQuery().getId();
+      this.sql_query_id = requestLogEvent.getQuery().getSqlQueryId();
+      this.datasource = findInnerDatasource(requestLogEvent.getQuery()).toString();
+      this.query = jsonMapper.writeValueAsString(requestLogEvent.getQuery());
+
+      this.output_result_size = (long) requestLogEvent.getQueryStats().getStats().getOrDefault(QUERY_BYTES_KEY, null);
+      this.execution_time = (long) requestLogEvent.getQueryStats().getStats().getOrDefault(QUERY_TIME_KEY, null);
+
+      this.imply_data_cube = (String) requestLogEvent.getQuery().getContextValue(IMPLY_DATA_CUBE_KEY, null);
+      this.imply_feature = (String) requestLogEvent.getQuery().getContextValue(IMPLY_FEATURE_KEY, null);
+      this.imply_user = (String) requestLogEvent.getQuery().getContextValue(IMPLY_USER_KEY, null);
+      this.imply_user_email = (String) requestLogEvent.getQuery().getContextValue(IMPLY_USER_EMAIL_KEY, null);
+      this.imply_view = (String) requestLogEvent.getQuery().getContextValue(IMPLY_VIEW_KEY, null);
+      this.imply_view_title = (String) requestLogEvent.getQuery().getContextValue(IMPLY_VIEW_TITLE_KEY, null);
+      this.imply_priority = (int) requestLogEvent.getQuery().getContextValue(IMPLY_PRIORITY_KEY, 0);
+    } else {
+      this.query = requestLogEvent.getSql();
+      this.is_sql_query = true;
+      this.sql_query_id = (String) requestLogEvent.getSqlQueryContext().getOrDefault(SQL_QUERY_ID_KEY, null);
+      this.native_query_id = (String) requestLogEvent.getSqlQueryContext().getOrDefault(NATIVE_QUERY_IDS_KEY, null);
+      this.output_result_size = (long) requestLogEvent.getQueryStats().getStats().getOrDefault(SQL_QUERY_BYTES_KEY, null);
+      this.execution_time = (long) requestLogEvent.getQueryStats().getStats().getOrDefault(SQL_QUERY_TIME_KEY, null);
+    }
+
+    this.success = (boolean) requestLogEvent.getQueryStats().getStats().getOrDefault(SUCCESS_KEY, null);
+    this.authenticator = (String) requestLogEvent.getQueryStats().getStats().getOrDefault(IDENTITY_KEY, null);
+    this.stats = jsonMapper.writeValueAsString(requestLogEvent.getQueryStats());
+    this.role = config.getRole();
+    this.druid_version = config.getDruidVersion();
+    this.environment = config.getEnvironment();
+    this.dataCenter = config.getDataCenter();
+    this.cluster_name = config.getClusterName();
+    this.creation_time = requestLogEvent.getCreatedTime().getMillis();
+    this.remote_address = requestLogEvent.getRemoteAddr();
+    this.service_name = requestLogEvent.getService();
+    this.host = requestLogEvent.getHost();
+  }
+
+  public TBase toThrift()
+  {
+    DruidQueryLogEvent thriftEvent = new DruidQueryLogEvent();
+
+    thriftEvent.setIs_sql_query(is_sql_query);
+    thriftEvent.setNative_query_id(native_query_id);
+    thriftEvent.setSql_query_id(sql_query_id);
+    thriftEvent.setDatasource(datasource);
+    thriftEvent.setQuery(query);
+
+    thriftEvent.setOutput_result_size(output_result_size);
+    thriftEvent.setExecution_time(execution_time);
+
+    thriftEvent.setImply_data_cube(imply_data_cube);
+    thriftEvent.setImply_feature(imply_feature);
+    thriftEvent.setImply_user(imply_user);
+    thriftEvent.setImply_user_email(imply_user_email);
+    thriftEvent.setImply_view(imply_view);
+    thriftEvent.setImply_view_title(imply_view_title);
+    thriftEvent.setImply_priority(imply_priority);
+
+    thriftEvent.setSuccess(success);
+    thriftEvent.setAuthenticator(authenticator);
+    thriftEvent.setStats(stats);
+    thriftEvent.setRole(role);
+    thriftEvent.setDruid_version(druid_version);
+    thriftEvent.setEnvironment(environment);
+    thriftEvent.setDatacenter(dataCenter);
+    thriftEvent.setCluster_name(cluster_name);
+    thriftEvent.setCreation_time(creation_time);
+    thriftEvent.setRemote_address(remote_address);
+    thriftEvent.setService_name(service_name);
+    thriftEvent.setHost(host);
+
+    return thriftEvent;
+  }
+
+  @Override
+  public String toString()
+  {
+    String resultString = "";
+
+    resultString += "native_query_id: " + native_query_id + "\n";
+    resultString += "sql_query_id: " + sql_query_id + "\n";
+    resultString += "role: " + role + "\n";
+    resultString += "druid_version: " + druid_version + "\n";
+    resultString += "environment: " + environment + "\n";
+    resultString += "datacenter: " + dataCenter + "\n";
+    resultString += "cluster_name: " + cluster_name + "\n";
+    resultString += "service_name: " + service_name + "\n";
+    resultString += "host: " + host + "\n";
+    resultString += "remote_address: " + remote_address + "\n";
+    resultString += "is_sql_query: " + is_sql_query + "\n";
+    resultString += "query: " + query + "\n";
+    resultString += "datasource: " + datasource + "\n";
+
+    resultString += "success: " + success + "\n";
+    resultString += "creation_time: " + creation_time + "\n";
+    resultString += "execution_time: " + execution_time + "\n";
+    resultString += "output_result_size: " + output_result_size + "\n";
+    resultString += "authenticator: " + authenticator + "\n";
+    resultString += "stats: " + stats + "\n";
+
+    resultString += "imply_data_cube: " + imply_data_cube + "\n";
+    resultString += "imply_feature: " + imply_feature + "\n";
+    resultString += "imply_user: " + imply_user + "\n";
+    resultString += "imply_user_email: " + imply_user_email + "\n";
+    resultString += "imply_view: " + imply_view + "\n";
+    resultString += "imply_view_title: " + imply_view_title + "\n";
+    resultString += "imply_priority: " + imply_priority + "\n";
+
+    return resultString;
+  }
+
+  public static ScribeRequestLogEntry createScribeRequestLogEntry(Event event, ScribeEmitterConfig config, ObjectMapper jsonMapper) throws JsonProcessingException
+  {
+    return new ScribeRequestLogEntry(event, config, jsonMapper);
+  }
+
+  private Object findInnerDatasource(Query query)
+  {
+    DataSource _ds = query.getDataSource();
+    if (_ds instanceof TableDataSource) {
+      return ((TableDataSource) _ds).getName();
+    }
+    if (_ds instanceof QueryDataSource) {
+      return findInnerDatasource(((QueryDataSource) _ds).getQuery());
+    }
+    if (_ds instanceof UnionDataSource) {
+      return Joiner.on(",")
+          .join(
+              ((UnionDataSource) _ds)
+                  .getDataSources()
+                  .stream()
+                  .map(TableDataSource::getName)
+                  .collect(Collectors.toList())
+          );
+    } else {
+      // should not come here
+      return query.getDataSource();
+    }
+  }
+}

--- a/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/TwitterLogScriber.java
+++ b/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/TwitterLogScriber.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.scribe;
+
+import com.twitter.logging.BareFormatter$;
+import com.twitter.logging.Level;
+import com.twitter.logging.LogRecord;
+import com.twitter.logging.QueueingHandler;
+import com.twitter.logging.ScribeHandler;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+import org.apache.thrift.TSerializer;
+import java.util.Base64;
+
+public class TwitterLogScriber
+{
+  private QueueingHandler queueingHandler;
+  private static final int MAX_QUEUE_SIZE = 1000;
+
+  // TSerializer is not thread safe
+  private final ThreadLocal<TSerializer> serializer = new ThreadLocal<TSerializer>() {
+    @Override
+    protected TSerializer initialValue()
+    {
+      return new TSerializer();
+    }
+  };
+
+  public TwitterLogScriber(String scribeCategory)
+  {
+    ScribeHandler scribeHandler = new ScribeHandler(
+        ScribeHandler.DefaultHostname(),
+        ScribeHandler.DefaultPort(),
+        scribeCategory,
+        ScribeHandler.DefaultBufferTime(),
+        ScribeHandler.DefaultConnectBackoff(),
+        ScribeHandler.DefaultMaxMessagesPerTransaction(),
+        ScribeHandler.DefaultMaxMessagesToBuffer(),
+        BareFormatter$.MODULE$,
+        scala.Option.apply((Level) null));
+    queueingHandler = new QueueingHandler(scribeHandler, MAX_QUEUE_SIZE);
+  }
+
+  public void scribe(TBase thriftMessage)
+      throws TException
+  {
+    scribe(serializeThriftToString(thriftMessage));
+  }
+
+  public void flush()
+  {
+    queueingHandler.flush();
+  }
+
+  public void close()
+  {
+    queueingHandler.close();
+  }
+
+  /**
+   * Serialize a thrift object to bytes, compress, then encode as a base64 string.
+   * Throws TException
+   */
+  private String serializeThriftToString(TBase thriftMessage)
+      throws TException
+  {
+    return Base64.getEncoder().encodeToString(serializer.get().serialize(thriftMessage));
+  }
+
+  private void scribe(String message)
+  {
+    LogRecord logRecord = new LogRecord(Level.ALL, message);
+    queueingHandler.publish(logRecord);
+  }
+}

--- a/extensions-twitter/scribe-emitter/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-twitter/scribe-emitter/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.druid.emitter.scribe.ScribeEmitterModule

--- a/extensions-twitter/scribe-emitter/src/main/resources/thrift/RequestLog.thrift
+++ b/extensions-twitter/scribe-emitter/src/main/resources/thrift/RequestLog.thrift
@@ -1,0 +1,33 @@
+namespace java org.apache.druid.emitter.scribe
+
+struct DruidQueryLogEvent {
+    1: required string native_query_id
+    2: optional string sql_query_id
+
+    3: optional string role
+    4: optional string druid_version
+    5: optional string environment
+    6: optional string datacenter
+    7: optional string cluster_name
+    8: optional string service_name
+    9: optional string host
+    10: optional string remote_address
+
+    11: required bool is_sql_query
+    12: required string query
+    13: optional string datasource
+    14: required bool success
+    15: required i64 creation_time
+    16: required i64 execution_time
+    17: required i64 output_result_size
+    18: required string authenticator
+    19: required string stats
+
+    20: optional string imply_data_cube
+    21: optional string imply_feature
+    22: optional string imply_user
+    23: optional string imply_user_email
+    24: optional string imply_view
+    25: optional string imply_view_title
+    26: optional i32 imply_priority
+}(persisted='true')

--- a/extensions-twitter/scribe-emitter/src/test/java/org/apache/druid/emitter/scribe/ScribeRequestLogEntryTest.java
+++ b/extensions-twitter/scribe-emitter/src/test/java/org/apache/druid/emitter/scribe/ScribeRequestLogEntryTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.scribe;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.query.TableDataSource;
+import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
+import org.apache.druid.query.timeseries.TimeseriesQuery;
+import org.apache.druid.segment.VirtualColumns;
+import org.apache.druid.server.QueryStats;
+import org.apache.druid.server.RequestLogLine;
+import org.apache.druid.server.log.DefaultRequestLogEventBuilderFactory;
+import org.apache.druid.server.log.RequestLogEvent;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ScribeRequestLogEntryTest
+{
+  @Test
+  public void testNativeQueryEntry() throws Exception
+  {
+    ObjectMapper objectMapper = new ObjectMapper();
+    RequestLogLine nativeLine = RequestLogLine.forNative(
+        new TimeseriesQuery(
+          new TableDataSource("dummy"),
+          new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2015-01-01/2015-01-02"))),
+          true,
+          VirtualColumns.EMPTY,
+          null,
+          Granularities.ALL,
+          ImmutableList.of(),
+          ImmutableList.of(),
+          5,
+          ImmutableMap.of("implyDataCube", "testCube",
+                          "implyFeature", "feature",
+                          "implyUser", "user1",
+                          "implyUserEmail", "user1@company.com",
+                          "priority", 1)),
+        DateTimes.of(2019, 12, 12, 3, 1),
+        "127.0.0.1",
+        new QueryStats(ImmutableMap.of("query/time", 13L, "query/bytes", 10L, "success", true, "identity", "allowAll"))
+    );
+    RequestLogEvent event = DefaultRequestLogEventBuilderFactory.instance().createRequestLogEventBuilder("feed", nativeLine).build(ImmutableMap.of("service", "broker", "host", "central-west-1"));
+
+    ScribeRequestLogEntry scribeEntry = new ScribeRequestLogEntry(event, new ScribeEmitterConfig("druid_query_log", "iq", "test", "0.16.1-tw-0.1", "central-west", "default-devel"), objectMapper);
+    String expectedResult = "native_query_id: null\n" +
+        "sql_query_id: null\n" +
+        "role: iq\n" +
+        "druid_version: 0.16.1-tw-0.1\n" +
+        "environment: test\n" +
+        "datacenter: central-west\n" +
+        "cluster_name: default-devel\n" +
+        "service_name: broker\n" +
+        "host: central-west-1\n" +
+        "remote_address: 127.0.0.1\n" +
+        "is_sql_query: false\n" +
+        "query: " + objectMapper.writeValueAsString(nativeLine.getQuery()) + "\n" +
+        "datasource: dummy\n" +
+        "success: true\n" +
+        "creation_time: 1576119660000\n" +
+        "execution_time: 13\n" +
+        "output_result_size: 10\n" +
+        "authenticator: allowAll\n" +
+        "stats: {\"query/time\":13,\"query/bytes\":10,\"success\":true,\"identity\":\"allowAll\"}\n" +
+        "imply_data_cube: testCube\n" +
+        "imply_feature: feature\n" +
+        "imply_user: user1\n" +
+        "imply_user_email: user1@company.com\n" +
+        "imply_view: null\n" +
+        "imply_view_title: null\n" +
+        "imply_priority: 1\n";
+    Assert.assertEquals(expectedResult, scribeEntry.toString());
+  }
+
+  @Test
+  public void testSqlQueryEntry() throws Exception
+  {
+    RequestLogLine sqlLine = RequestLogLine.forSql(
+        "SELECT * FROM table LIMIT 10",
+        ImmutableMap.of("", ""),
+        DateTimes.of(2019, 12, 12, 3, 1),
+        "127.0.0.1",
+        new QueryStats(ImmutableMap.of("sqlQuery/time", 13L, "sqlQuery/bytes", 10L, "success", true, "identity", "allowAll"))
+    );
+    RequestLogEvent event = DefaultRequestLogEventBuilderFactory.instance().createRequestLogEventBuilder("feed", sqlLine).build(ImmutableMap.of("service", "broker", "host", "central-west-1"));
+
+    ScribeRequestLogEntry scribeEntry = new ScribeRequestLogEntry(event, new ScribeEmitterConfig("druid_query_log", "iq", "test", "0.16.1-tw-0.1", "central-west", "default-devel"), new ObjectMapper());
+    String expectedResult = "native_query_id: null\n" +
+        "sql_query_id: null\n" +
+        "role: iq\n" +
+        "druid_version: 0.16.1-tw-0.1\n" +
+        "environment: test\n" +
+        "datacenter: central-west\n" +
+        "cluster_name: default-devel\n" +
+        "service_name: broker\n" +
+        "host: central-west-1\n" +
+        "remote_address: 127.0.0.1\n" +
+        "is_sql_query: true\n" +
+        "query: SELECT * FROM table LIMIT 10\n" +
+        "datasource: null\n" +
+        "success: true\n" +
+        "creation_time: 1576119660000\n" +
+        "execution_time: 13\n" +
+        "output_result_size: 10\n" +
+        "authenticator: allowAll\n" +
+        "stats: {\"sqlQuery/time\":13,\"sqlQuery/bytes\":10,\"success\":true,\"identity\":\"allowAll\"}\n" +
+        "imply_data_cube: null\n" +
+        "imply_feature: null\n" +
+        "imply_user: null\n" +
+        "imply_user_email: null\n" +
+        "imply_view: null\n" +
+        "imply_view_title: null\n" +
+        "imply_priority: 0\n";
+    Assert.assertEquals(expectedResult, scribeEntry.toString());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,8 @@
         <module>extensions-contrib/moving-average-query</module>
         <module>extensions-contrib/tdigestsketch</module>
         <module>extensions-contrib/influxdb-emitter</module>
+        <!-- Twitter-specific extensions -->
+        <module>extensions-twitter/scribe-emitter</module>
         <!-- distribution packaging -->
         <module>distribution</module>
     </modules>

--- a/server/src/main/java/org/apache/druid/server/log/DefaultRequestLogEvent.java
+++ b/server/src/main/java/org/apache/druid/server/log/DefaultRequestLogEvent.java
@@ -96,6 +96,12 @@ public final class DefaultRequestLogEvent implements RequestLogEvent
     return request.getSql();
   }
 
+  @JsonProperty("sqlQueryContext")
+  public Map<String, Object> getSqlQueryContext()
+  {
+    return request.getSqlQueryContext();
+  }
+
   @JsonProperty("remoteAddr")
   public String getRemoteAddr()
   {


### PR DESCRIPTION
As part of the larger audit logging work, Twitter would like to know who is accessing what data. One way to do this is by recording all executed queries on Druid for future audit. To do this, we are planning to use Twitter's internal Scribe based log collection framework. In this PR, I have added support for Scribe as a possible emitter medium and also added code so that we can emit RequestLogEvents