### PR TITLE
First Draft of Administrative Changes Audit Logging support

### DIFF
--- a/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeAdminLogEntry.java
+++ b/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeAdminLogEntry.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.scribe;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.java.util.emitter.core.Event;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.thrift.TBase;
+
+public class ScribeAdminLogEntry
+{
+  private static final String AUDIT_KEY = "key";
+  private static final String AUDIT_TYPE = "type";
+  private static final String AUTHOR = "author";
+  private static final String COMMENT = "comment";
+  private static final String IP = "remote_address";
+  private static final String CREATED_DATE = "created_date";
+  private static final String PAYLOAD = "payload";
+
+  private String audit_key;
+  private String audit_type;
+  private String author;
+  private String comment;
+  private String remote_address;
+  private String created_date;
+  private String payload;
+
+  private String role;
+  private String druid_version;
+  private String environment;
+  private String dataCenter;
+  private String cluster_name;
+
+  public ScribeAdminLogEntry(Event event, ScribeEmitterConfig config, ObjectMapper jsonMapper) throws JsonProcessingException
+  {
+    ServiceMetricEvent adminLogEvent = (ServiceMetricEvent) event;
+
+    this.audit_key = (String) adminLogEvent.getUserDims().getOrDefault(AUDIT_KEY, null);
+    this.audit_type = (String) adminLogEvent.getUserDims().getOrDefault(AUDIT_TYPE, null);
+    this.author = (String) adminLogEvent.getUserDims().getOrDefault(AUTHOR, null);
+    this.comment = (String) adminLogEvent.getUserDims().getOrDefault(COMMENT, null);
+    this.remote_address = (String) adminLogEvent.getUserDims().getOrDefault(IP, null);
+    this.created_date = (String) adminLogEvent.getUserDims().getOrDefault(CREATED_DATE, null);
+    this.payload = jsonMapper.writeValueAsString(adminLogEvent.getUserDims().getOrDefault(PAYLOAD, null));
+
+    this.role = config.getRole();
+    this.druid_version = config.getDruidVersion();
+    this.environment = config.getEnvironment();
+    this.dataCenter = config.getDataCenter();
+    this.cluster_name = config.getClusterName();
+  }
+
+  public TBase toThrift()
+  {
+    DruidAdminLogEvent thriftEvent = new DruidAdminLogEvent();
+    thriftEvent.setAudit_key(audit_key);
+    thriftEvent.setAudit_type(audit_type);
+    thriftEvent.setAuthor(author);
+    thriftEvent.setComment(comment);
+    thriftEvent.setRemote_address(remote_address);
+    thriftEvent.setCreated_date(created_date);
+    thriftEvent.setPayload(payload);
+    thriftEvent.setRole(role);
+    thriftEvent.setDruid_version(druid_version);
+    thriftEvent.setEnvironment(environment);
+    thriftEvent.setDatacenter(dataCenter);
+    thriftEvent.setCluster_name(cluster_name);
+    return thriftEvent;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "audit_key: " + audit_key + "\n"
+           + "audit_type: " + audit_type + "\n"
+           + "author: " + author + "\n"
+           + "comment: " + comment + "\n"
+           + "remote_address: " + remote_address + "\n"
+           + "created_date: " + created_date + "\n"
+           + "payload: " + payload + "\n"
+           + "role: " + role + "\n"
+           + "druid_version: " + druid_version + "\n"
+           + "environment: " + environment + "\n"
+           + "datacenter: " + dataCenter + "\n"
+           + "cluster_name: " + cluster_name + "\n";
+  }
+
+  public static ScribeAdminLogEntry createScribeAdminLogEntry(Event event, ScribeEmitterConfig config, ObjectMapper jsonMapper) throws JsonProcessingException
+  {
+    return new ScribeAdminLogEntry(event, config, jsonMapper);
+  }
+}

--- a/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeEmitterConfig.java
+++ b/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeEmitterConfig.java
@@ -28,6 +28,9 @@ public class ScribeEmitterConfig
   private final String requestLogScribeCategory;
 
   @JsonProperty
+  private final String adminLogScribeCategory;
+
+  @JsonProperty
   private final String role;
 
   @JsonProperty
@@ -57,6 +60,9 @@ public class ScribeEmitterConfig
     if (!getRequestLogScribeCategory().equals(that.getRequestLogScribeCategory())) {
       return false;
     }
+    if (!getAdminLogScribeCategory().equals(that.getAdminLogScribeCategory())) {
+      return false;
+    }
     if (!getRole().equals(that.getRole())) {
       return false;
     }
@@ -79,6 +85,7 @@ public class ScribeEmitterConfig
   public int hashCode()
   {
     int result = getRequestLogScribeCategory().hashCode();
+    result = 31 * result + getAdminLogScribeCategory().hashCode();
     result = 31 * result + getRole().hashCode();
     result = 31 * result + getEnvironment().hashCode();
     result = 31 * result + getDruidVersion().hashCode();
@@ -90,6 +97,7 @@ public class ScribeEmitterConfig
   @JsonCreator
   public ScribeEmitterConfig(
       @JsonProperty("requestLogScribeCategory") String requestLogScribeCategory,
+      @JsonProperty("adminLogScribeCategory") String adminLogScribeCategory,
       @JsonProperty("role") String role,
       @JsonProperty("environment") String environment,
       @JsonProperty("druidVersion") String druidVersion,
@@ -98,6 +106,7 @@ public class ScribeEmitterConfig
   )
   {
     this.requestLogScribeCategory = requestLogScribeCategory;
+    this.adminLogScribeCategory = adminLogScribeCategory;
     this.role = role;
     this.environment = environment;
     this.druidVersion = druidVersion;
@@ -109,6 +118,12 @@ public class ScribeEmitterConfig
   public String getRequestLogScribeCategory()
   {
     return requestLogScribeCategory;
+  }
+
+  @JsonProperty
+  public String getAdminLogScribeCategory()
+  {
+    return adminLogScribeCategory;
   }
 
   @JsonProperty

--- a/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeRequestLogEntry.java
+++ b/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeRequestLogEntry.java
@@ -163,38 +163,34 @@ public class ScribeRequestLogEntry
   @Override
   public String toString()
   {
-    String resultString = "";
+    return "native_query_id: " + native_query_id + "\n"
+            + "sql_query_id: " + sql_query_id + "\n"
+            + "role: " + role + "\n"
+            + "druid_version: " + druid_version + "\n"
+            + "environment: " + environment + "\n"
+            + "datacenter: " + dataCenter + "\n"
+            + "cluster_name: " + cluster_name + "\n"
+            + "service_name: " + service_name + "\n"
+            + "host: " + host + "\n"
+            + "remote_address: " + remote_address + "\n"
+            + "is_sql_query: " + is_sql_query + "\n"
+            + "query: " + query + "\n"
+            + "datasource: " + datasource + "\n"
 
-    resultString += "native_query_id: " + native_query_id + "\n";
-    resultString += "sql_query_id: " + sql_query_id + "\n";
-    resultString += "role: " + role + "\n";
-    resultString += "druid_version: " + druid_version + "\n";
-    resultString += "environment: " + environment + "\n";
-    resultString += "datacenter: " + dataCenter + "\n";
-    resultString += "cluster_name: " + cluster_name + "\n";
-    resultString += "service_name: " + service_name + "\n";
-    resultString += "host: " + host + "\n";
-    resultString += "remote_address: " + remote_address + "\n";
-    resultString += "is_sql_query: " + is_sql_query + "\n";
-    resultString += "query: " + query + "\n";
-    resultString += "datasource: " + datasource + "\n";
+            + "success: " + success + "\n"
+            + "creation_time: " + creation_time + "\n"
+            + "execution_time: " + execution_time + "\n"
+            + "output_result_size: " + output_result_size + "\n"
+            + "authenticator: " + authenticator + "\n"
+            + "stats: " + stats + "\n"
 
-    resultString += "success: " + success + "\n";
-    resultString += "creation_time: " + creation_time + "\n";
-    resultString += "execution_time: " + execution_time + "\n";
-    resultString += "output_result_size: " + output_result_size + "\n";
-    resultString += "authenticator: " + authenticator + "\n";
-    resultString += "stats: " + stats + "\n";
-
-    resultString += "imply_data_cube: " + imply_data_cube + "\n";
-    resultString += "imply_feature: " + imply_feature + "\n";
-    resultString += "imply_user: " + imply_user + "\n";
-    resultString += "imply_user_email: " + imply_user_email + "\n";
-    resultString += "imply_view: " + imply_view + "\n";
-    resultString += "imply_view_title: " + imply_view_title + "\n";
-    resultString += "imply_priority: " + imply_priority + "\n";
-
-    return resultString;
+            + "imply_data_cube: " + imply_data_cube + "\n"
+            + "imply_feature: " + imply_feature + "\n"
+            + "imply_user: " + imply_user + "\n"
+            + "imply_user_email: " + imply_user_email + "\n"
+            + "imply_view: " + imply_view + "\n"
+            + "imply_view_title: " + imply_view_title + "\n"
+            + "imply_priority: " + imply_priority + "\n";
   }
 
   public static ScribeRequestLogEntry createScribeRequestLogEntry(Event event, ScribeEmitterConfig config, ObjectMapper jsonMapper) throws JsonProcessingException

--- a/extensions-twitter/scribe-emitter/src/main/resources/thrift/AdminLog.thrift
+++ b/extensions-twitter/scribe-emitter/src/main/resources/thrift/AdminLog.thrift
@@ -1,0 +1,17 @@
+namespace java org.apache.druid.emitter.scribe
+
+struct DruidAdminLogEvent {
+    1: required string audit_key
+    2: required string audit_type
+    3: required string author
+    4: required string comment
+    5: required string remote_address
+    6: required string created_date
+    7: required string payload
+
+    8: optional string role
+    9: optional string druid_version
+    10: optional string environment
+    11: optional string datacenter
+    12: optional string cluster_name
+}(persisted='true')

--- a/extensions-twitter/scribe-emitter/src/test/java/org/apache/druid/emitter/scribe/ScribeAdminLogEntryTest.java
+++ b/extensions-twitter/scribe-emitter/src/test/java/org/apache/druid/emitter/scribe/ScribeAdminLogEntryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.scribe;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ScribeAdminLogEntryTest
+{
+  @Test
+  public void testRetentionChangeEntry() throws Exception
+  {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    ScribeAdminLogEntry scribeEntry = new ScribeAdminLogEntry(new ServiceMetricEvent.Builder()
+                                                                  .setDimension("key", "key1")
+                                                                  .setDimension("type", "rules")
+                                                                  .setDimension("author", "myname")
+                                                                  .setDimension("comment", "Have to change the rules")
+                                                                  .setDimension("remote_address", "127.0.0.1")
+                                                                  .setDimension("created_date", "123456789000")
+                                                                  .setDimension("payload", "key:value")
+                                                                  .build("config/audit", 1)
+                                                                  .build("druid/coordinator", "127.0.0.11"),
+                                                              new ScribeEmitterConfig("druid_request_log", "druid_admin_log", "iq",
+                                                                                                 "test", "0.16.1-tw-0.1", "central-west", "default-devel"),
+                                                              objectMapper);
+    String expectedResult = "audit_key: key1\n" +
+        "audit_type: rules\n" +
+        "author: myname\n" +
+        "comment: Have to change the rules\n" +
+        "remote_address: 127.0.0.1\n" +
+        "created_date: 123456789000\n" +
+        "payload: \"key:value\"\n" +
+        "role: iq\n" +
+        "druid_version: 0.16.1-tw-0.1\n" +
+        "environment: test\n" +
+        "datacenter: central-west\n" +
+        "cluster_name: default-devel\n";
+    Assert.assertEquals(expectedResult, scribeEntry.toString());
+  }
+}

--- a/extensions-twitter/scribe-emitter/src/test/java/org/apache/druid/emitter/scribe/ScribeRequestLogEntryTest.java
+++ b/extensions-twitter/scribe-emitter/src/test/java/org/apache/druid/emitter/scribe/ScribeRequestLogEntryTest.java
@@ -64,7 +64,7 @@ public class ScribeRequestLogEntryTest
     );
     RequestLogEvent event = DefaultRequestLogEventBuilderFactory.instance().createRequestLogEventBuilder("feed", nativeLine).build(ImmutableMap.of("service", "broker", "host", "central-west-1"));
 
-    ScribeRequestLogEntry scribeEntry = new ScribeRequestLogEntry(event, new ScribeEmitterConfig("druid_query_log", "iq", "test", "0.16.1-tw-0.1", "central-west", "default-devel"), objectMapper);
+    ScribeRequestLogEntry scribeEntry = new ScribeRequestLogEntry(event, new ScribeEmitterConfig("druid_query_log", "druid_admin_log", "iq", "test", "0.16.1-tw-0.1", "central-west", "default-devel"), objectMapper);
     String expectedResult = "native_query_id: null\n" +
         "sql_query_id: null\n" +
         "role: iq\n" +
@@ -106,7 +106,7 @@ public class ScribeRequestLogEntryTest
     );
     RequestLogEvent event = DefaultRequestLogEventBuilderFactory.instance().createRequestLogEventBuilder("feed", sqlLine).build(ImmutableMap.of("service", "broker", "host", "central-west-1"));
 
-    ScribeRequestLogEntry scribeEntry = new ScribeRequestLogEntry(event, new ScribeEmitterConfig("druid_query_log", "iq", "test", "0.16.1-tw-0.1", "central-west", "default-devel"), new ObjectMapper());
+    ScribeRequestLogEntry scribeEntry = new ScribeRequestLogEntry(event, new ScribeEmitterConfig("druid_query_log", "druid_admin_log", "iq", "test", "0.16.1-tw-0.1", "central-west", "default-devel"), new ObjectMapper());
     String expectedResult = "native_query_id: null\n" +
         "sql_query_id: null\n" +
         "role: iq\n" +

--- a/server/src/main/java/org/apache/druid/server/audit/SQLAuditManager.java
+++ b/server/src/main/java/org/apache/druid/server/audit/SQLAuditManager.java
@@ -101,6 +101,10 @@ public class SQLAuditManager implements AuditManager
             .setDimension("key", auditEntry.getKey())
             .setDimension("type", auditEntry.getType())
             .setDimension("author", auditEntry.getAuditInfo().getAuthor())
+            .setDimension("comment", auditEntry.getAuditInfo().getComment())
+            .setDimension("remote_address", auditEntry.getAuditInfo().getIp())
+            .setDimension("created_date", auditEntry.getAuditTime().toString())
+            .setDimension("payload", auditEntry.getPayload())
             .build("config/audit", 1)
     );
 


### PR DESCRIPTION
Administrative Logging incorporates changes to retention rule and lookups. Currently Druid uses MySQL for logging these changes. To better integrate with Twitter audit logging framework, we have leveraged the ServiceMetricEvent to scribe these messages to Twitter's log pipeline.