### PR TITLE
First Draft of Druid Indexing Audit Logging

### DIFF
--- a/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeEmitterConfig.java
+++ b/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeEmitterConfig.java
@@ -31,6 +31,9 @@ public class ScribeEmitterConfig
   private final String adminLogScribeCategory;
 
   @JsonProperty
+  private final String indexingLogScribeCategory;
+
+  @JsonProperty
   private final String role;
 
   @JsonProperty
@@ -63,6 +66,9 @@ public class ScribeEmitterConfig
     if (!getAdminLogScribeCategory().equals(that.getAdminLogScribeCategory())) {
       return false;
     }
+    if (!getIndexingLogScribeCategory().equals(that.getIndexingLogScribeCategory())) {
+      return false;
+    }
     if (!getRole().equals(that.getRole())) {
       return false;
     }
@@ -86,6 +92,7 @@ public class ScribeEmitterConfig
   {
     int result = getRequestLogScribeCategory().hashCode();
     result = 31 * result + getAdminLogScribeCategory().hashCode();
+    result = 31 * result + getIndexingLogScribeCategory().hashCode();
     result = 31 * result + getRole().hashCode();
     result = 31 * result + getEnvironment().hashCode();
     result = 31 * result + getDruidVersion().hashCode();
@@ -98,6 +105,7 @@ public class ScribeEmitterConfig
   public ScribeEmitterConfig(
       @JsonProperty("requestLogScribeCategory") String requestLogScribeCategory,
       @JsonProperty("adminLogScribeCategory") String adminLogScribeCategory,
+      @JsonProperty("indexingLogScribeCategory") String indexingLogScribeCategory,
       @JsonProperty("role") String role,
       @JsonProperty("environment") String environment,
       @JsonProperty("druidVersion") String druidVersion,
@@ -107,6 +115,7 @@ public class ScribeEmitterConfig
   {
     this.requestLogScribeCategory = requestLogScribeCategory;
     this.adminLogScribeCategory = adminLogScribeCategory;
+    this.indexingLogScribeCategory = indexingLogScribeCategory;
     this.role = role;
     this.environment = environment;
     this.druidVersion = druidVersion;
@@ -124,6 +133,12 @@ public class ScribeEmitterConfig
   public String getAdminLogScribeCategory()
   {
     return adminLogScribeCategory;
+  }
+
+  @JsonProperty
+  public String getIndexingLogScribeCategory()
+  {
+    return indexingLogScribeCategory;
   }
 
   @JsonProperty

--- a/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeIndexingLogEntry.java
+++ b/extensions-twitter/scribe-emitter/src/main/java/org/apache/druid/emitter/scribe/ScribeIndexingLogEntry.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.scribe;
+
+import org.apache.druid.java.util.emitter.core.Event;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.query.DruidMetrics;
+import org.apache.thrift.TBase;
+
+public class ScribeIndexingLogEntry
+{
+  private String task_id;
+  private String task_type;
+  private String datasource;
+  private String task_status;
+  private String owner;
+  private long duration;
+  private long creation_time;
+
+  private String role;
+  private String druid_version;
+  private String environment;
+  private String dataCenter;
+  private String cluster_name;
+
+  public ScribeIndexingLogEntry(Event event, ScribeEmitterConfig config)
+  {
+    ServiceMetricEvent indexingLogEvent = (ServiceMetricEvent) event;
+
+    this.task_id = (String) indexingLogEvent.getUserDims().getOrDefault(DruidMetrics.TASK_ID, null);
+    this.task_type = (String) indexingLogEvent.getUserDims().getOrDefault(DruidMetrics.TASK_TYPE, null);
+    this.datasource = (String) indexingLogEvent.getUserDims().getOrDefault(DruidMetrics.DATASOURCE, null);
+    this.task_status = (String) indexingLogEvent.getUserDims().getOrDefault(DruidMetrics.TASK_STATUS, null);
+    this.duration = indexingLogEvent.getValue().longValue();
+    this.creation_time = indexingLogEvent.getCreatedTime().getMillis();
+    this.owner = config.getRole();
+
+    this.role = config.getRole();
+    this.druid_version = config.getDruidVersion();
+    this.environment = config.getEnvironment();
+    this.dataCenter = config.getDataCenter();
+    this.cluster_name = config.getClusterName();
+  }
+
+  public TBase toThrift()
+  {
+    DruidIndexingLogEvent thriftEvent = new DruidIndexingLogEvent();
+    thriftEvent.setTask_id(task_id);
+    thriftEvent.setTask_type(task_type);
+    thriftEvent.setDatasource(datasource);
+    thriftEvent.setTask_status(task_status);
+    thriftEvent.setDuration(duration);
+    thriftEvent.setCreation_time(creation_time);
+    thriftEvent.setOwner(owner);
+
+    thriftEvent.setRole(role);
+    thriftEvent.setDruid_version(druid_version);
+    thriftEvent.setEnvironment(environment);
+    thriftEvent.setDatacenter(dataCenter);
+    thriftEvent.setCluster_name(cluster_name);
+    return thriftEvent;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "task_id: " + task_id + "\n"
+           + "task_type: " + task_type + "\n"
+           + "datasource: " + datasource + "\n"
+           + "task_status: " + task_status + "\n"
+           + "duration: " + duration + "\n"
+           + "creation_time: " + creation_time + "\n"
+           + "owner: " + owner + "\n"
+           + "role: " + role + "\n"
+           + "druid_version: " + druid_version + "\n"
+           + "environment: " + environment + "\n"
+           + "datacenter: " + dataCenter + "\n"
+           + "cluster_name: " + cluster_name + "\n";
+  }
+
+  public static ScribeIndexingLogEntry createScribeIndexingLogEntry(Event event, ScribeEmitterConfig config)
+  {
+    return new ScribeIndexingLogEntry(event, config);
+  }
+}

--- a/extensions-twitter/scribe-emitter/src/main/resources/thrift/IndexingLog.thrift
+++ b/extensions-twitter/scribe-emitter/src/main/resources/thrift/IndexingLog.thrift
@@ -1,0 +1,17 @@
+namespace java org.apache.druid.emitter.scribe
+
+struct DruidIndexingLogEvent {
+    1: required string task_id
+    2: required string task_type
+    3: required string datasource
+    4: required string task_status
+    5: required i64 duration
+    6: required i64 creation_time
+    7: required string owner
+
+    8: optional string role
+    9: optional string druid_version
+    10: optional string environment
+    11: optional string datacenter
+    12: optional string cluster_name
+}(persisted='true')

--- a/extensions-twitter/scribe-emitter/src/test/java/org/apache/druid/emitter/scribe/ScribeAdminLogEntryTest.java
+++ b/extensions-twitter/scribe-emitter/src/test/java/org/apache/druid/emitter/scribe/ScribeAdminLogEntryTest.java
@@ -41,8 +41,8 @@ public class ScribeAdminLogEntryTest
                                                                   .setDimension("payload", "key:value")
                                                                   .build("config/audit", 1)
                                                                   .build("druid/coordinator", "127.0.0.11"),
-                                                              new ScribeEmitterConfig("druid_request_log", "druid_admin_log", "iq",
-                                                                                                 "test", "0.16.1-tw-0.1", "central-west", "default-devel"),
+                                                              new ScribeEmitterConfig("druid_request_log", "druid_admin_log", "druid_indexing_log",
+                                                                                      "iq", "test", "0.16.1-tw-0.1", "central-west", "default-devel"),
                                                               objectMapper);
     String expectedResult = "audit_key: key1\n" +
         "audit_type: rules\n" +

--- a/extensions-twitter/scribe-emitter/src/test/java/org/apache/druid/emitter/scribe/ScribeIndexingLogEntryTest.java
+++ b/extensions-twitter/scribe-emitter/src/test/java/org/apache/druid/emitter/scribe/ScribeIndexingLogEntryTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.scribe;
+
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.query.DruidMetrics;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ScribeIndexingLogEntryTest
+{
+  @Test
+  public void testIndexingLogEntry()
+  {
+    DateTime now = DateTimes.nowUtc();
+    ScribeIndexingLogEntry scribeEntry = new ScribeIndexingLogEntry(new ServiceMetricEvent.Builder()
+                                                                      .setDimension(DruidMetrics.TASK_ID, "index_kafka_dsname")
+                                                                      .setDimension(DruidMetrics.TASK_TYPE, "index_kafka")
+                                                                      .setDimension(DruidMetrics.DATASOURCE, "dsname")
+                                                                      .setDimension(DruidMetrics.TASK_STATUS, "SUCCESS")
+                                                                      .build(now, "task/run/time", 2000300)
+                                                                      .build("druid/overlord", "127.0.0.11"),
+                                                                    new ScribeEmitterConfig("druid_request_log",
+                                                                                             "druid_admin_log",
+                                                                                           "druid_indexing_log",
+                                                                                                             "iq", "test",
+                                                                                                      "0.16.1-tw-0.1", "central-west",
+                                                                                                      "default-devel"));
+    String expectedResult = "task_id: index_kafka_dsname\n" +
+        "task_type: index_kafka\n" +
+        "datasource: dsname\n" +
+        "task_status: SUCCESS\n" +
+        "duration: 2000300\n" +
+        "creation_time: " + now.getMillis() + "\n" +
+        "owner: iq\n" +
+        "role: iq\n" +
+        "druid_version: 0.16.1-tw-0.1\n" +
+        "environment: test\n" +
+        "datacenter: central-west\n" +
+        "cluster_name: default-devel\n";
+    Assert.assertEquals(expectedResult, scribeEntry.toString());
+  }
+}

--- a/extensions-twitter/scribe-emitter/src/test/java/org/apache/druid/emitter/scribe/ScribeRequestLogEntryTest.java
+++ b/extensions-twitter/scribe-emitter/src/test/java/org/apache/druid/emitter/scribe/ScribeRequestLogEntryTest.java
@@ -64,7 +64,7 @@ public class ScribeRequestLogEntryTest
     );
     RequestLogEvent event = DefaultRequestLogEventBuilderFactory.instance().createRequestLogEventBuilder("feed", nativeLine).build(ImmutableMap.of("service", "broker", "host", "central-west-1"));
 
-    ScribeRequestLogEntry scribeEntry = new ScribeRequestLogEntry(event, new ScribeEmitterConfig("druid_query_log", "druid_admin_log", "iq", "test", "0.16.1-tw-0.1", "central-west", "default-devel"), objectMapper);
+    ScribeRequestLogEntry scribeEntry = new ScribeRequestLogEntry(event, new ScribeEmitterConfig("druid_query_log", "druid_admin_log", "druid_indexing_log", "iq", "test", "0.16.1-tw-0.1", "central-west", "default-devel"), objectMapper);
     String expectedResult = "native_query_id: null\n" +
         "sql_query_id: null\n" +
         "role: iq\n" +
@@ -106,7 +106,7 @@ public class ScribeRequestLogEntryTest
     );
     RequestLogEvent event = DefaultRequestLogEventBuilderFactory.instance().createRequestLogEventBuilder("feed", sqlLine).build(ImmutableMap.of("service", "broker", "host", "central-west-1"));
 
-    ScribeRequestLogEntry scribeEntry = new ScribeRequestLogEntry(event, new ScribeEmitterConfig("druid_query_log", "druid_admin_log", "iq", "test", "0.16.1-tw-0.1", "central-west", "default-devel"), new ObjectMapper());
+    ScribeRequestLogEntry scribeEntry = new ScribeRequestLogEntry(event, new ScribeEmitterConfig("druid_query_log", "druid_admin_log", "druid_indexing_log", "iq", "test", "0.16.1-tw-0.1", "central-west", "default-devel"), new ObjectMapper());
     String expectedResult = "native_query_id: null\n" +
         "sql_query_id: null\n" +
         "role: iq\n" +


### PR DESCRIPTION
We implement the Druid indexing audit logging in this PR. At a high level, at the end of each task (batch hadoop, batch native, streaming, etc) Druid emits the task run time. We listen for this metric and emit out the details into our scribe logger. Note the current implementation does not have any notion of who triggered this ingestion as Druid does not support impersonation at this time. When such a support is added, we need to modify this code path to ensure the actor is also audited as part of this logging.