### PR TITLE
Set a default user to workaround the unmapped uid issue AURORA-15361 …

### DIFF
--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetExtensionsModule.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetExtensionsModule.java
@@ -31,6 +31,7 @@ import org.apache.druid.data.input.parquet.simple.ParquetParseSpec;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -71,6 +72,8 @@ public class ParquetExtensionsModule implements DruidModule
   {
     // this block of code is common among extensions that use Hadoop things but are not running in Hadoop, in order
     // to properly initialize everything
+
+    UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser("user"));
 
     final Configuration conf = new Configuration();
 


### PR DESCRIPTION
Adding parquet extension in GCP is not possible because the extension expects the uid to be set in container. While that is true in AURORA it is not the case in GKE. As a result we have to add this hack as a workaround. For context check out this ticket https://jira.twitter.biz/browse/AURORA-15361. We should eventually get rid of this hack once GKE container UID issue is fixed